### PR TITLE
Add development tools to Docker dev image

### DIFF
--- a/utils/docker-dev-env/Dockerfile
+++ b/utils/docker-dev-env/Dockerfile
@@ -1,14 +1,34 @@
 FROM ubuntu:18.04
-ENV MAGIC_AKS_GIT_URL 'https://github.com/sachinkundu/akstf.git'
+ENV MAGIC_AKS_GIT_URL "https://github.com/sachinkundu/akstf.git"
+ENV FLUX_VER "1.21.1"
+ENV TERRAFORM_VER "0.14.6"
 WORKDIR /root/
 
 # Install tools and clone the Magic AKS repository
 RUN apt-get update && \
     apt-get install -y curl && \
     apt-get install -y git && \
-    apt-get install -u unzip &&
-    curl -sL https://aka.ms/InstallAzureCLIDeb | bash && \
-    git clone ${MAGIC_AKS_GIT_URL}
+    apt-get install -u unzip
+
+# Tool - Azure CLI
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash 
+
+# Tool - Kubectl
+RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
+    apt-get update && \
+    apt-get install -y kubectl
+
+# Tool - Fluxctl
+RUN curl -L https://github.com/fluxcd/flux/releases/download/${FLUX_VER}/fluxctl_linux_amd64 -o /usr/local/bin/fluxctl && \
+    chmod a+x /usr/local/bin/fluxctl
+
+# Tool - Terraform
+RUN curl -LO https://releases.hashicorp.com/terraform/${TERRAFORM_VER}/terraform_${TERRAFORM_VER}_linux_amd64.zip && \
+    unzip terraform_${TERRAFORM_VER}_linux_amd64.zip && \
+    mv terraform /usr/local/bin/
+
+RUN git clone ${MAGIC_AKS_GIT_URL}
 
 RUN echo 'alias ll="ls -l"' >> ~/.bashrc
 WORKDIR /root/akstf/

--- a/utils/docker-dev-env/Dockerfile
+++ b/utils/docker-dev-env/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /root/
 RUN apt-get update && \
     apt-get install -y curl && \
     apt-get install -y git && \
+    apt-get install -u unzip &&
     curl -sL https://aka.ms/InstallAzureCLIDeb | bash && \
     git clone ${MAGIC_AKS_GIT_URL}
 

--- a/utils/docker-dev-env/Dockerfile
+++ b/utils/docker-dev-env/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-ENV MAGIC_AKS_GIT_URL "https://github.com/sachinkundu/akstf.git"
+ENV MAGIC_AKS_GIT_URL "https://github.com/magicaks/magicaks.git"
 ENV FLUX_VER "1.21.1"
 ENV TERRAFORM_VER "0.14.6"
 WORKDIR /root/

--- a/utils/docker-dev-env/Dockerfile
+++ b/utils/docker-dev-env/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 ENV MAGIC_AKS_GIT_URL "https://github.com/magicaks/magicaks.git"
 ENV FLUX_VER "1.21.1"
-ENV TERRAFORM_VER "0.14.6"
+ENV TERRAFORM_VER "0.14.2"
 WORKDIR /root/
 
 # Install tools and clone the Magic AKS repository

--- a/utils/docker-dev-env/Dockerfile
+++ b/utils/docker-dev-env/Dockerfile
@@ -31,4 +31,4 @@ RUN curl -LO https://releases.hashicorp.com/terraform/${TERRAFORM_VER}/terraform
 RUN git clone ${MAGIC_AKS_GIT_URL}
 
 RUN echo 'alias ll="ls -l"' >> ~/.bashrc
-WORKDIR /root/akstf/
+WORKDIR /root/magicaks/

--- a/utils/docker-dev-env/README.md
+++ b/utils/docker-dev-env/README.md
@@ -25,13 +25,23 @@ This Docker image provides an isolated development environment with the required
 1. Now inside the running Docker container, list files to verify the image was properly created:
 
     ```plaintext
-    root@626be9d44688:~/akstf# ls -a
+    root@626be9d44688:~/magicaks# ll -a
     ````
 
     The files in the root of the cloned Magic AKS repository are listed:
 
     ```plaintext
-    .  ..  .git  .github  .gitignore  1-preprovision  2-provision-aks  3-postprovision  README.md  fabrikate-defs  utils
+    .  
+    ..  
+    .git  
+    .github  
+    .gitignore  
+    1-preprovision  
+    2-provision-aks  
+    3-postprovision  
+    README.md  
+    fabrikate-defs  
+    utils
     ```
 
 > Do not forget to login to Azure ("`az login`" command) and to select the correct subscriptuon ("`az account set --subscription <subscription ID>`" command) before running the setup scripts in the `utils` folder.


### PR DESCRIPTION
This pull requests includes the required tools in the development Docker image:

* Azure CLI
* Kubectl
* Fluxctl
* Terraform

Additionally, the image now also clones the MagicAKS repository rather then the legacy AKSTF repository.